### PR TITLE
Source Maps

### DIFF
--- a/config/assets.json
+++ b/config/assets.json
@@ -11,6 +11,16 @@
 	"should_optimize": null,
 
 	/**
+		Whether or not source maps should be generated.
+		Current supported options are "auto" or false.
+
+		If false, no source maps are generated.
+		If "auto", source maps will be inlined during development
+		and saved to file.ext.map on assets:publish
+	*/
+	"source_maps": "auto",
+
+	/**
 		Config options for each compiler
 	*/
 	"compilers": {

--- a/src/AssetFactory.js
+++ b/src/AssetFactory.js
@@ -8,14 +8,16 @@ export class AssetFactory {
 	app = null
 	published = null
 	shouldOptimizeDefault = null
+	sourceMapsDefault = false
 
 	_compilers = [ ]
 	_postProcessors = [ ]
 
-	constructor(app, shouldOptimizeDefault = false) {
+	constructor(app, shouldOptimizeDefault = false, sourceMapsDefault = 'auto') {
 		this.app = app
 		this.published = app.config.get('assets-published', { })
 		this.shouldOptimizeDefault = shouldOptimizeDefault
+		this.sourceMapsDefault = sourceMapsDefault
 	}
 
 	make(path) {
@@ -24,7 +26,7 @@ export class AssetFactory {
 
 	registerCompiler(compiler) {
 		if(typeof compiler === 'function') {
-			compiler = new compiler(this.app)
+			compiler = new compiler(this.app, this.sourceMapsDefault)
 		}
 
 		if(!(compiler instanceof Compiler)) {
@@ -37,7 +39,7 @@ export class AssetFactory {
 
 	registerPostProcessor(postProcessor) {
 		if(typeof postProcessor === 'function') {
-			postProcessor = new postProcessor(this.app, this.shouldOptimizeDefault)
+			postProcessor = new postProcessor(this.app, this.shouldOptimizeDefault, this.sourceMapsDefault)
 		}
 
 		if(!(postProcessor instanceof PostProcessor)) {

--- a/src/AssetsProvider.js
+++ b/src/AssetsProvider.js
@@ -69,7 +69,8 @@ export function AssetsProvider(app, parameters = { }) {
 	app.config.set('assets', config)
 
 	const shouldOptimize = typeof config.should_optimize === 'boolean' ? config.should_optimize : !app.debug
-	const factory = new AssetFactory(app, shouldOptimize)
+	const sourceMaps = config.source_maps === 'auto' ? 'auto' : false
+	const factory = new AssetFactory(app, shouldOptimize, sourceMaps)
 	app.assets = factory
 
 	factory.registerCompiler(BabelCompiler)

--- a/src/Commands/BaseCommand.js
+++ b/src/Commands/BaseCommand.js
@@ -4,8 +4,18 @@ import '../Support/FS'
 
 export class BaseCommand extends Command {
 
-	removeAsset(asset) {
-		return FS.unlink(this.app.paths.public(asset)).catch(err => {
+	async removeAsset(asset) {
+		const path = this.app.paths.public(asset)
+		const mapPath = `${path}.map`
+
+		const hasMap = await FS.exists(mapPath)
+		const promises = [ FS.unlink(path) ]
+
+		if(hasMap) {
+			promises.push(FS.unlink(mapPath))
+		}
+
+		return Promise.all(promises).catch(err => {
 			Log.comment('Unable to remove', asset, err.message)
 		})
 	}

--- a/src/Compilers/BabelCompiler.js
+++ b/src/Compilers/BabelCompiler.js
@@ -14,13 +14,13 @@ export class BabelCompiler extends Compiler {
 	browserifyOptions = [ ]
 	priority = 1000
 
-	constructor(app) {
-		super(app)
+	constructor(app, sourceMaps) {
+		super(app, sourceMaps)
 
 		this.browserifyOptions = app.config.get('assets.compilers.babel.browserify', { })
 
 		if(this.browserifyOptions.debug.isNil) {
-			this.browserifyOptions.debug = true
+			this.browserifyOptions.debug = this.sourceMaps === 'auto'
 		}
 	}
 
@@ -68,7 +68,7 @@ export class BabelCompiler extends Compiler {
 		const contents = await FS.readFile(pathname)
 		const importPaths = [ ]
 
-		contents.toString().replace(/import\s*\{[^\}]+\}\s*from\s*((["'`]).+?(\2))/igm, (_, importPath) => {
+		contents.toString().replace(/import\s*\{[^}]+\}\s*from\s*((["'`]).+?(\2))/igm, (_, importPath) => {
 			importPaths.push(importPath)
 		})
 
@@ -76,7 +76,7 @@ export class BabelCompiler extends Compiler {
 			importPaths.push(importPath)
 		})
 
-		contents.toString().replace(/require\s*\(([^\)]+)\)/ig, (_, importPath) => {
+		contents.toString().replace(/require\s*\(([^)]+)\)/ig, (_, importPath) => {
 			importPaths.push(importPath)
 		})
 

--- a/src/Compilers/Compiler.js
+++ b/src/Compilers/Compiler.js
@@ -7,9 +7,11 @@ export class Compiler {
 	priority = 0
 	supportedExtensions = [ ]
 	wantsHashSuffixOnPublish = true
+	sourceMaps = 'auto'
 
-	constructor(app) {
+	constructor(app, sourceMaps) {
 		this.app = app
+		this.sourceMaps = sourceMaps
 	}
 
 	// eslint-disable-next-line no-unused-vars

--- a/src/Compilers/RawCompiler.js
+++ b/src/Compilers/RawCompiler.js
@@ -9,8 +9,8 @@ export class RawCompiler extends Compiler {
 	extensions = null
 	assets = null
 
-	constructor(app, autoMinify) {
-		super(app, autoMinify)
+	constructor(app, sourceMaps) {
+		super(app, sourceMaps)
 
 		this.assets = app.paths.base('resources/assets')
 		this.extensions = app.config.get('assets.compilers.raw.extensions')

--- a/src/Compilers/ScssCompiler.js
+++ b/src/Compilers/ScssCompiler.js
@@ -12,19 +12,15 @@ export class ScssCompiler extends Compiler {
 	options = { }
 	priority = 1000
 
-	constructor(app, autoMinify) {
-		super(app, autoMinify)
+	constructor(app, sourceMaps) {
+		super(app, sourceMaps)
 
 		this.options = app.config.get('assets.compilers.scss', { })
 
-		if(
-			this.options.sourceMap.isNil
-			&& this.options.sourceMapEmbed.isNil
-			&& this.options.sourceMapContents.isNil
-		) {
-			this.options.sourceMap = true
-			this.options.sourceMapEmbed = true
-			this.options.sourceMapContents = true
+		if(this.options.sourceMap.isNil && this.options.sourceMapEmbed.isNil && this.options.sourceMapContents.isNil) {
+			this.options.sourceMap = this.sourceMaps === 'auto'
+			this.options.sourceMapEmbed = this.sourceMaps === 'auto'
+			this.options.sourceMapContents = this.sourceMaps === 'auto'
 		}
 	}
 

--- a/src/PostProcessors/CssAutoprefixerPostProcessor.js
+++ b/src/PostProcessors/CssAutoprefixerPostProcessor.js
@@ -10,13 +10,13 @@ export class CssAutoprefixerPostProcessor extends PostProcessor {
 	supportedExtensions = [ 'css' ]
 	options = { }
 
-	constructor(app, shouldOptimize) {
-		super(app, shouldOptimize)
+	constructor(app, shouldOptimize, sourceMaps) {
+		super(app, shouldOptimize, sourceMaps)
 
 		this.options = app.config.get('assets.post_processors.css.autoprefix', { })
 		this.shouldOptimize = this.options.enabled || true
 
-		if(this.options.sourceMap.isNil) {
+		if(this.options.sourceMap.isNil && this.sourceMaps === 'auto') {
 			this.options.sourceMap = true
 		}
 	}

--- a/src/PostProcessors/JavascriptMinifyPostProcessor.js
+++ b/src/PostProcessors/JavascriptMinifyPostProcessor.js
@@ -1,15 +1,17 @@
 import './PostProcessor'
 
+import '../Support/FS'
 import '../Support/Require'
 
 const UglifyJS = Require.optionally('uglify-js')
+const INLINE_SOURCE_MAP_REGEX = /\/\/[@#]\s+sourceMappingURL=data:application\/json(?:;charset[:=][^;]+)?;base64,(.*)\n/
 
 export class JavascriptMinifyPostProcessor extends PostProcessor {
 	supportedExtensions = [ 'js' ]
 	options = { }
 
-	constructor(app, shouldOptimize) {
-		super(app, shouldOptimize)
+	constructor(app, shouldOptimize, sourceMaps) {
+		super(app, shouldOptimize, sourceMaps)
 
 		this.options = app.config.get('assets.post_processors.js.minify', { })
 
@@ -28,20 +30,47 @@ export class JavascriptMinifyPostProcessor extends PostProcessor {
 			return Promise.resolve(contents)
 		}
 
+		const useSourceMap = this.sourceMaps === 'auto'
+		const inlineSourceMap = useSourceMap && targetPath.isNil
+		let sourceMap = null
+
+		if(useSourceMap) {
+			contents = contents.toString().replace(INLINE_SOURCE_MAP_REGEX, (_, map) => {
+				sourceMap = JSON.parse((new Buffer(map, 'base64')).toString())
+				return ''
+			})
+		}
+
 		return new Promise((resolve, reject) => {
 			let result = null
+			const targetPathMap = `${targetPath}.map`
 
 			try {
-				result = UglifyJS.minify(contents.toString(), Object.assign({ }, this.options, {
-					fromString: true
-				}))
+				const options = Object.assign({ }, this.options, {
+					fromString: true,
+					inSourceMap: sourceMap,
+				})
+
+				if(useSourceMap) {
+					if(inlineSourceMap) {
+						options.sourceMapInline = true
+					} else {
+						options.outSourceMap = true
+					}
+				}
+
+				result = UglifyJS.minify(contents.toString(), options)
 			} catch(err) {
 				err.file = sourcePath
 				err.column = err.col
 				return reject(err)
 			}
 
-			resolve(result.code)
+			if(result.map.isNil || inlineSourceMap || !useSourceMap) {
+				return resolve(result.code)
+			}
+
+			resolve(FS.writeFile(targetPathMap, result.map).then(() => result.code))
 		})
 	}
 

--- a/src/PostProcessors/PostProcessor.js
+++ b/src/PostProcessors/PostProcessor.js
@@ -1,18 +1,21 @@
-import path from 'path'
+import Path from 'path'
 
 export class PostProcessor {
 	app = null
 	priority = 0
 	supportedExtensions = [ ]
+	shouldOptimize = false
+	sourceMaps = false
 
-	constructor(app, shouldOptimize) {
+	constructor(app, shouldOptimize, sourceMaps) {
 		this.app = app
 		this.shouldOptimize = shouldOptimize
+		this.sourceMaps = sourceMaps
 	}
 
 	// eslint-disable-next-line no-unused-vars
 	supports(sourcePath) {
-		return this.supportedExtensions.indexOf(path.extname(sourcePath).replace(/^\./, '')) >= 0
+		return this.supportedExtensions.indexOf(Path.extname(sourcePath).replace(/^\./, '')) >= 0
 	}
 
 	// eslint-disable-next-line no-unused-vars

--- a/src/PostProcessors/SvgOptimizePostProcessor.js
+++ b/src/PostProcessors/SvgOptimizePostProcessor.js
@@ -1,6 +1,5 @@
 import './PostProcessor'
 
-import '../Support/FS'
 import '../Support/Require'
 
 const SVGO = Require.optionally('svgo')
@@ -9,8 +8,8 @@ export class SvgOptimizePostProcessor extends PostProcessor {
 	supportedExtensions = [ 'svg' ]
 	options = { }
 
-	constructor(app, shouldOptimize) {
-		super(app, shouldOptimize)
+	constructor(app, shouldOptimize, sourceMaps) {
+		super(app, shouldOptimize, sourceMaps)
 
 		this.options = app.config.get('assets.post_processors.svg.optimize', { })
 


### PR DESCRIPTION
Adds proper support for source maps via a new `source_maps` config key.

Current supported options are "auto" or false:

* If false, no source maps are generated.
* If "auto", source maps will be inlined during development and saved to file.ext.map on assets:publish